### PR TITLE
Update all dependencies

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,5 @@
+style = defaultWithAlign
+
+maxColumn = 120
+docstrings = JavaDoc
+rewrite.rules = [AsciiSortImports]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 jdk:
   - oraclejdk8
 scala:
-  - 2.11.8
-  - 2.12.1
+  - 2.11.12
+  - 2.12.8
 script: "sbt clean coverage test coverageReport"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,3 @@
-import scalariform.formatter.preferences._
-import com.typesafe.sbt.SbtScalariform
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 name := "prometheus-akka-http"
 
@@ -36,15 +33,7 @@ libraryDependencies ++= {
 
 fork := true
 
-SbtScalariform.scalariformSettings
-
-ScalariformKeys.preferences := ScalariformKeys.preferences.value
-  .setPreference(AlignSingleLineCaseStatements, true)
-  .setPreference(DoubleIndentClassDeclaration, true)
-  .setPreference(SpacesAroundMultiImports, false)
-  .setPreference(CompactControlReadability, false)
-
-bintrayOrganization := Some("lonelyplanet")
+//bintrayOrganization := Some("lonelyplanet")
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
@@ -54,7 +43,7 @@ val publishSettings =
   if (version.toString.endsWith("-SNAPSHOT"))
     Seq(
       publishTo := Some("Artifactory Realm" at "http://oss.jfrog.org/artifactory/oss-snapshot-local"),
-      bintrayReleaseOnPublish := false,
+      //bintrayReleaseOnPublish := false,
       credentials := List(Path.userHome / ".bintray" / ".artifactory").filter(_.exists).map(Credentials(_))
     )
   else

--- a/build.sbt
+++ b/build.sbt
@@ -13,21 +13,22 @@ resolvers += "Sonatype release repository" at "https://oss.sonatype.org/content/
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
 libraryDependencies ++= {
-  val simpleclientVersion = "0.3.0"
-  val akkaVersion         = "2.5.11"
-  val akkaHttpVersion     = "10.1.1"
-  val scalaTestVersion    = "3.0.4"
+  val simpleclientVersion = "0.6.0"
+  val akkaVersion         = "2.5.19"
+  val akkaHttpVersion     = "10.1.7"
+  val scalaTestVersion    = "3.0.5"
 
   Seq(
-    "com.typesafe.akka"    %% "akka-actor"                           % akkaVersion % "provided",
-    "com.typesafe.akka"    %% "akka-stream"                          % akkaVersion % "provided",
-    "com.typesafe.akka"    %% "akka-http"                            % akkaHttpVersion % "provided",
-    "com.typesafe.akka"    %% "akka-http-spray-json"                 % akkaHttpVersion % "provided",
+    "com.typesafe.akka"    %% "akka-actor"                           % akkaVersion % Provided,
+    "com.typesafe.akka"    %% "akka-stream"                          % akkaVersion % Provided,
+    "com.typesafe.akka"    %% "akka-http"                            % akkaHttpVersion % Provided,
+    "com.typesafe.akka"    %% "akka-http-spray-json"                 % akkaHttpVersion % Provided,
     "io.prometheus"        %  "simpleclient"                         % simpleclientVersion,
     "io.prometheus"        %  "simpleclient_common"                  % simpleclientVersion,
-    "org.scalamock"        %% "scalamock-scalatest-support"          % "3.6.0" % "test",
-    "com.typesafe.akka"    %% "akka-http-testkit"                    % akkaHttpVersion % "test",
-    "org.scalatest"        %% "scalatest"                            % scalaTestVersion % "test"
+    "org.scalamock"        %% "scalamock-scalatest-support"          % "3.6.0" % Test,
+    "com.typesafe.akka"    %% "akka-testkit"                         % akkaVersion % Test,
+    "com.typesafe.akka"    %% "akka-http-testkit"                    % akkaHttpVersion % Test,
+    "org.scalatest"        %% "scalatest"                            % scalaTestVersion % Test,
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,26 +34,24 @@ libraryDependencies ++= {
 
 fork := true
 
-//bintrayOrganization := Some("lonelyplanet")
+bintrayOrganization := Some("lonelyplanet")
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
-
-val doNotPublishSettings = Seq(publish := {})
 
 val publishSettings =
   if (version.toString.endsWith("-SNAPSHOT"))
     Seq(
       publishTo := Some("Artifactory Realm" at "http://oss.jfrog.org/artifactory/oss-snapshot-local"),
-      //bintrayReleaseOnPublish := false,
+      bintrayReleaseOnPublish := false,
       credentials := List(Path.userHome / ".bintray" / ".artifactory").filter(_.exists).map(Credentials(_))
     )
   else
     Seq(
-      organization := "com.lonelyplanet",
-      pomExtra := <scm>
-        <url>https://github.com/lonelyplanet/prometheus-akka-http</url>
-        <connection>https://github.com/lonelyplanet/prometheus-akka-http</connection>
-      </scm>
+      pomExtra :=
+        <scm>
+          <url>https://github.com/lonelyplanet/prometheus-akka-http</url>
+          <connection>https://github.com/lonelyplanet/prometheus-akka-http</connection>
+        </scm>
         <developers>
           <developer>
             <id>toddkazakov</id>

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ organization := "com.lonelyplanet"
 
 version := "0.3.5"
 
-scalaVersion := "2.11.8"
-crossScalaVersions := Seq("2.11.8", "2.12.2")
+scalaVersion := "2.12.8"
+crossScalaVersions := Seq(scalaVersion.value, "2.11.12")
 
 resolvers += "Sonatype release repository" at "https://oss.sonatype.org/content/repositories/releases/"
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ libraryDependencies ++= {
 }
 
 fork := true
+scalafmtOnCompile := true
 
 bintrayOrganization := Some("lonelyplanet")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("com.geirsson"      % "sbt-scalafmt"   % "1.5.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray"    % "0.5.4")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"  % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,0 @@
-logLevel := Level.Warn
-
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")

--- a/src/main/scala/com/lonelyplanet/prometheus/EventObserver.scala
+++ b/src/main/scala/com/lonelyplanet/prometheus/EventObserver.scala
@@ -1,6 +1,6 @@
 package com.lonelyplanet.prometheus
 
-import io.prometheus.client.{Counter, CollectorRegistry}
+import io.prometheus.client.{CollectorRegistry, Counter}
 
 trait EventObserver {
   def observe(eventName: String, eventDetails: String): Unit
@@ -25,11 +25,12 @@ class PrometheusEventObserver(
 
   val counter = buildCounter.register(registry)
 
-  private def buildCounter = Counter
-    .build()
-    .name(metricName)
-    .help(metricHelp)
-    .labelNames(eventLabelName, eventDetailsLabelName)
+  private def buildCounter =
+    Counter
+      .build()
+      .name(metricName)
+      .help(metricHelp)
+      .labelNames(eventLabelName, eventDetailsLabelName)
 
   override def observe(eventName: String, eventDetails: String): Unit = {
     counter.labels(eventName, eventDetails).inc()
@@ -39,14 +40,15 @@ class PrometheusEventObserver(
 object PrometheusEventObserver {
   private val SuccessfulOperationMetricName = "operation_success"
   private val SuccessfulOperationMetricHelp = "The number of observed successful operations"
-  private val FailedOperationMetricName = "operation_failure"
-  private val FailedOperationMetricHelp = "The number of observed failed operations"
-  private val DefaultEventLabelName = "event"
-  private val DefaultEventDetailsLabelName = "details"
-  private val DefaultRegistry = CollectorRegistry.defaultRegistry
+  private val FailedOperationMetricName     = "operation_failure"
+  private val FailedOperationMetricHelp     = "The number of observed failed operations"
+  private val DefaultEventLabelName         = "event"
+  private val DefaultEventDetailsLabelName  = "details"
+  private val DefaultRegistry               = CollectorRegistry.defaultRegistry
 
   // Common event observers used in scala projects in Open Planet micro-services
-  lazy val SuccessfulOperations = withDefaultsFromMetricNameAndHelp(SuccessfulOperationMetricName, SuccessfulOperationMetricHelp)
+  lazy val SuccessfulOperations =
+    withDefaultsFromMetricNameAndHelp(SuccessfulOperationMetricName, SuccessfulOperationMetricHelp)
   lazy val FailedOperations = withDefaultsFromMetricNameAndHelp(FailedOperationMetricName, FailedOperationMetricHelp)
 
   private def withDefaultsFromMetricNameAndHelp(metricName: String, metricHelp: String) = {

--- a/src/main/scala/com/lonelyplanet/prometheus/ResponseTimeRecorder.scala
+++ b/src/main/scala/com/lonelyplanet/prometheus/ResponseTimeRecorder.scala
@@ -35,21 +35,23 @@ class PrometheusResponseTimeRecorder(
     responseTimes.labels(endpoint).observe(responseTime.toUnit(timeUnit))
   }
 
-  private def buildHistogram = Histogram.build()
-    .name(metricName)
-    .help(metricHelp)
-    .labelNames(endpointLabelName)
-    .buckets(buckets: _*)
+  private def buildHistogram =
+    Histogram
+      .build()
+      .name(metricName)
+      .help(metricHelp)
+      .labelNames(endpointLabelName)
+      .buckets(buckets: _*)
 
 }
 
 object PrometheusResponseTimeRecorder {
-  val DefaultBuckets = List(.01, .025, .05, .075, .10, .125, .15, .175, .20, .225, .25, .275,
-    .30, .325, .35, .40, .45, .50, .60, .70, 1.0, 2.0, 3.0, 5.0, 10.0)
-  val DefaultMetricName = "request_processing_seconds"
-  val DefaultMetricHelp = "Time spent processing request"
+  val DefaultBuckets = List(.01, .025, .05, .075, .10, .125, .15, .175, .20, .225, .25, .275, .30, .325, .35, .40, .45,
+    .50, .60, .70, 1.0, 2.0, 3.0, 5.0, 10.0)
+  val DefaultMetricName    = "request_processing_seconds"
+  val DefaultMetricHelp    = "Time spent processing request"
   val DefaultEndpointLabel = "endpoint"
-  val DefaultTimeUnit = duration.SECONDS
+  val DefaultTimeUnit      = duration.SECONDS
 
   lazy val DefaultRegistry = CollectorRegistry.defaultRegistry
 

--- a/src/main/scala/com/lonelyplanet/prometheus/api/MetricFamilySamplesEntity.scala
+++ b/src/main/scala/com/lonelyplanet/prometheus/api/MetricFamilySamplesEntity.scala
@@ -22,7 +22,6 @@ object MetricFamilySamplesEntity {
   def toPrometheusTextFormat(e: MetricFamilySamplesEntity): String = {
     val writer: Writer = new StringWriter()
     TextFormat.write004(writer, e.samples)
-
     writer.toString
   }
 
@@ -33,4 +32,3 @@ object MetricFamilySamplesEntity {
   }
 
 }
-

--- a/src/main/scala/com/lonelyplanet/prometheus/api/MetricFamilySamplesEntity.scala
+++ b/src/main/scala/com/lonelyplanet/prometheus/api/MetricFamilySamplesEntity.scala
@@ -3,7 +3,7 @@ package com.lonelyplanet.prometheus.api
 import java.io.{StringWriter, Writer}
 import java.util
 
-import akka.http.scaladsl.marshalling.{ToEntityMarshaller, Marshaller}
+import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
 import akka.http.scaladsl.model._
 import io.prometheus.client.Collector.MetricFamilySamples
 import io.prometheus.client.CollectorRegistry
@@ -12,8 +12,14 @@ import io.prometheus.client.exporter.common.TextFormat
 case class MetricFamilySamplesEntity(samples: util.Enumeration[MetricFamilySamples])
 
 object MetricFamilySamplesEntity {
-  private val mediaTypeParams = Map("version" -> "0.0.4")
-  private val mediaType = MediaType.customWithFixedCharset("text", "plain", HttpCharsets.`UTF-8`, params = mediaTypeParams)
+  val version = "0.0.4"
+
+  private val mediaType = MediaType.customWithFixedCharset(
+    mainType = "text",
+    subType = "plain",
+    charset = HttpCharsets.`UTF-8`,
+    params = Map("version" -> version)
+  )
 
   def fromRegistry(collectorRegistry: CollectorRegistry): MetricFamilySamplesEntity = {
     MetricFamilySamplesEntity(collectorRegistry.metricFamilySamples())

--- a/src/main/scala/com/lonelyplanet/prometheus/directives/ResponseTimeRecordingDirectives.scala
+++ b/src/main/scala/com/lonelyplanet/prometheus/directives/ResponseTimeRecordingDirectives.scala
@@ -38,7 +38,7 @@ trait ResponseTimeRecordingDirectives {
 
   private def record(endpoint: String, requestStartTime: Long): Unit = {
     val requestEndTime = System.nanoTime()
-    val total = new FiniteDuration(requestEndTime - requestStartTime, duration.NANOSECONDS)
+    val total          = new FiniteDuration(requestEndTime - requestStartTime, duration.NANOSECONDS)
 
     recorder.recordResponseTime(endpoint, total)
   }

--- a/src/test/scala/com/lonelyplanet/prometheus/PrometheusEventObserverSpec.scala
+++ b/src/test/scala/com/lonelyplanet/prometheus/PrometheusEventObserverSpec.scala
@@ -7,13 +7,13 @@ import org.scalatest.{FlatSpec, Matchers}
 class PrometheusEventObserverSpec extends FlatSpec with Matchers {
 
   "PrometheusEventObserver" should "record observed events in a counter" in {
-    val registry = new CollectorRegistry()
-    val randomMetricName = generateRandomString
-    val randomMetricHelp = generateRandomString
-    val randomEventLabelName = generateRandomString
+    val registry                    = new CollectorRegistry()
+    val randomMetricName            = generateRandomString
+    val randomMetricHelp            = generateRandomString
+    val randomEventLabelName        = generateRandomString
     val randomEventDetailsLabelName = generateRandomString
 
-    val randomEventName = generateRandomString
+    val randomEventName    = generateRandomString
     val randomEventDetails = generateRandomString
 
     val eventObserver = new PrometheusEventObserver(

--- a/src/test/scala/com/lonelyplanet/prometheus/PrometheusEventObserverSpec.scala
+++ b/src/test/scala/com/lonelyplanet/prometheus/PrometheusEventObserverSpec.scala
@@ -1,10 +1,11 @@
 package com.lonelyplanet.prometheus
 
 import com.lonelyplanet.prometheus.Utils._
-import io.prometheus.client.{Collector, CollectorRegistry}
-import org.scalatest.{Matchers, FlatSpec}
+import io.prometheus.client.CollectorRegistry
+import org.scalatest.{FlatSpec, Matchers}
 
 class PrometheusEventObserverSpec extends FlatSpec with Matchers {
+
   "PrometheusEventObserver" should "record observed events in a counter" in {
     val registry = new CollectorRegistry()
     val randomMetricName = generateRandomString

--- a/src/test/scala/com/lonelyplanet/prometheus/PrometheusResponseTimeRecorderSpec.scala
+++ b/src/test/scala/com/lonelyplanet/prometheus/PrometheusResponseTimeRecorderSpec.scala
@@ -12,12 +12,12 @@ import scala.util.Random
 class PrometheusResponseTimeRecorderSpec extends FlatSpec with Matchers with MockFactory {
 
   "PrometheusLatencyRecorder" should "register a histogram and record request latencies" in {
-    val registry = new CollectorRegistry()
-    val randomMetricName = generateRandomString
-    val randomMetricHelp = generateRandomString
-    val randomLabelName = generateRandomString
+    val registry           = new CollectorRegistry()
+    val randomMetricName   = generateRandomString
+    val randomMetricHelp   = generateRandomString
+    val randomLabelName    = generateRandomString
     val randomEndpointName = generateRandomString
-    val randomLatency = Math.abs(Random.nextInt(10000))
+    val randomLatency      = Math.abs(Random.nextInt(10000))
 
     // our random value will end up in the second bucket
     val buckets = List((randomLatency - 1).toDouble, (randomLatency + 1).toDouble)
@@ -33,20 +33,30 @@ class PrometheusResponseTimeRecorderSpec extends FlatSpec with Matchers with Moc
 
     recorder.recordResponseTime(randomEndpointName, FiniteDuration(randomLatency, duration.MILLISECONDS))
 
-    val first = getBucketValue(registry, randomMetricName, List(randomLabelName), List(randomEndpointName), buckets.head)
-    val second = getBucketValue(registry, randomMetricName, List(randomLabelName), List(randomEndpointName), buckets.last)
-    val positiveInf = getBucketValue(registry, randomMetricName, List(randomLabelName), List(randomEndpointName), Double.PositiveInfinity)
+    val first =
+      getBucketValue(registry, randomMetricName, List(randomLabelName), List(randomEndpointName), buckets.head)
+    val second =
+      getBucketValue(registry, randomMetricName, List(randomLabelName), List(randomEndpointName), buckets.last)
+    val positiveInf = getBucketValue(registry,
+                                     randomMetricName,
+                                     List(randomLabelName),
+                                     List(randomEndpointName),
+                                     Double.PositiveInfinity)
 
     first shouldBe 0
     second shouldBe 1
     positiveInf shouldBe 1
   }
 
-  private def getBucketValue(registry: CollectorRegistry, metricName: String, labelNames: List[String], labelValues: List[String], bucket: Double) = {
+  private def getBucketValue(registry: CollectorRegistry,
+                             metricName: String,
+                             labelNames: List[String],
+                             labelValues: List[String],
+                             bucket: Double) = {
     val name = metricName + "_bucket"
 
     // 'le' should be the first label in the list
-    val allLabelNames = (Array("le") ++ labelNames).reverse
+    val allLabelNames  = (Array("le") ++ labelNames).reverse
     val allLabelValues = (Array(Collector.doubleToGoString(bucket)) ++ labelValues).reverse
     registry.getSampleValue(name, allLabelNames, allLabelValues).intValue()
   }

--- a/src/test/scala/com/lonelyplanet/prometheus/api/MetricsEndpointSpec.scala
+++ b/src/test/scala/com/lonelyplanet/prometheus/api/MetricsEndpointSpec.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.model.HttpCharsets
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.lonelyplanet.prometheus.Utils._
 import io.prometheus.client.exporter.common.TextFormat
-import io.prometheus.client.{Histogram, CollectorRegistry}
-import org.scalatest.{Matchers, FlatSpec}
+import io.prometheus.client.{CollectorRegistry, Histogram}
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
 
@@ -25,13 +25,13 @@ class MetricsEndpointSpec extends FlatSpec with Matchers with ScalatestRouteTest
 
   it should "return serialized metrics in the prometheus text format" in {
     val registry = new CollectorRegistry()
-    val api = createEndpoint(registry)
-    val hist = Histogram.build().name(RandomTestName).help(RandomTestHelp).linearBuckets(0, 1, 10).register(registry)
+    val api      = createEndpoint(registry)
+    val hist     = Histogram.build().name(RandomTestName).help(RandomTestHelp).linearBuckets(0, 1, 10).register(registry)
 
     hist.observe(Math.abs(Random.nextDouble()))
 
     Get("/metrics") ~> api.routes ~> check {
-      val resp = responseAs[String]
+      val resp   = responseAs[String]
       val writer = new StringWriter()
       TextFormat.write004(writer, registry.metricFamilySamples())
 


### PR DESCRIPTION
This library isn't compatible with akka-http `10.1.6` and on onward. 

This PR updates all the dependencies. It would be great if you could publish a new release with it `0.4.0`, for both Scala 2.11 and 2.12. 

**No logic change**