### PR TITLE
Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
   - 2.11.12
   - 2.12.8
-script: "sbt clean coverage test coverageReport"
+  - 2.13.0
+script: "sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Collection of utilities to allow exposing prometheus metrics from akka-http endpoint using the prometheus java client
 
-    "com.lonelyplanet" %% "prometheus-akka-http" % "0.4.0"
+    "com.lonelyplanet" %% "prometheus-akka-http" % "0.4.1"
     
 You might need to also add our repository:
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,19 +4,19 @@ name := "prometheus-akka-http"
 
 organization := "com.lonelyplanet"
 
-version := "0.4.0"
+version := "0.4.1"
 
-crossScalaVersions := Seq("2.12.8", "2.11.12")
+crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12")
 
-resolvers += "Sonatype release repository" at "https://oss.sonatype.org/content/repositories/releases/"
+resolvers += Resolver.sonatypeRepo("releases")
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
 libraryDependencies ++= {
   val simpleclientVersion = "0.6.0"
-  val akkaVersion         = "2.5.19"
-  val akkaHttpVersion     = "10.1.7"
-  val scalaTestVersion    = "3.0.5"
+  val akkaVersion         = "2.5.23"
+  val akkaHttpVersion     = "10.1.8"
+  val scalaTestVersion    = "3.0.8"
 
   Seq(
     "com.typesafe.akka"    %% "akka-actor"                           % akkaVersion % Provided,
@@ -25,7 +25,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"    %% "akka-http-spray-json"                 % akkaHttpVersion % Provided,
     "io.prometheus"        %  "simpleclient"                         % simpleclientVersion,
     "io.prometheus"        %  "simpleclient_common"                  % simpleclientVersion,
-    "org.scalamock"        %% "scalamock-scalatest-support"          % "3.6.0" % Test,
+    "org.scalamock"        %% "scalamock"                            % "4.3.0" % Test,
     "com.typesafe.akka"    %% "akka-testkit"                         % akkaVersion % Test,
     "com.typesafe.akka"    %% "akka-http-testkit"                    % akkaHttpVersion % Test,
     "org.scalatest"        %% "scalatest"                            % scalaTestVersion % Test,
@@ -38,7 +38,7 @@ scalariformAutoformat := true
 
 scalariformPreferences := scalariformPreferences.value
   .setPreference(AlignSingleLineCaseStatements, true)
-  .setPreference(DoubleIndentClassDeclaration, true)
+  .setPreference(DoubleIndentConstructorArguments, true)
   .setPreference(SpacesAroundMultiImports, false)
   .setPreference(CompactControlReadability, false)
 
@@ -72,3 +72,18 @@ val publishSettings =
       publishMavenStyle := false,
       resolvers += Resolver.url("lonelyplanet ivy resolver", url("http://dl.bintray.com/lonelyplanet/maven"))(Resolver.ivyStylePatterns)
     )
+
+lazy val scoverageSettings = Seq(
+  coverageEnabled := {
+    if (priorTo2_13(scalaVersion.value))
+      coverageEnabled.value
+    else
+      false
+  }
+)
+
+def priorTo2_13(scalaVersion: String): Boolean =
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, minor)) if minor < 13 => true
+    case _                              => false
+  }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scalariform"   % "sbt-scalariform" % "1.8.2")
-addSbtPlugin("org.foundweekends" % "sbt-bintray"     % "0.5.4")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage"   % "1.5.1")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")


### PR DESCRIPTION
This is still work in progress as the scoverage plugin does not support 2.13 yet.

If you have any tips on getting SBT to stop loading the scoverage plugin for 2.13 I would be gratefull to put those changes in and update this PR.